### PR TITLE
Add browser support check for navigator.storage in OPFS retrieval

### DIFF
--- a/src/scripts/storage/getOpfs.ts
+++ b/src/scripts/storage/getOpfs.ts
@@ -1,5 +1,11 @@
 export async function getOpfs(directory = 'md', create = true) {
-	const estimation = await navigator.storage.estimate()
-	console.debug(`Used ${(estimation.usage / estimation.quota * 100).toFixed(2)}% of storage quota`)
-	return (await navigator.storage.getDirectory()).getDirectoryHandle(directory, { create: create })
+  if (!navigator.storage) {
+    console.error("navigator.storage is not supported in this browser environment. OPFS cannot be used.");
+    // CRITICAL: Return null or throw an error, since we cannot proceed.
+    return null;
+  }
+
+  const estimation = await navigator.storage.estimate();
+  console.debug(`Used ${(estimation.usage / estimation.quota * 100).toFixed(2)}% of storage quota`);
+  return (await navigator.storage.getDirectory()).getDirectoryHandle(directory, { create: create });
 }


### PR DESCRIPTION
Stops the app from crashing when storage isn't available. Instead of freezing when trying to use navigator.storage (which some browsers don't support), it now just keeps running without saving notes. Better to have a working notepad than a frozen screen.